### PR TITLE
[FIX] vm not found issue when calling vmonkey with -e argument

### DIFF
--- a/vipermonkey/vmonkey.py
+++ b/vipermonkey/vmonkey.py
@@ -1634,6 +1634,10 @@ def process_file_scanexpr (container, filename, data):
     try:
         #TODO: handle olefile errors, when an OLE file is malformed
         import oletools
+
+        # Start the vm support. Used when call with argument -e 
+        vm = ViperMonkey(filename, data)
+
         oletools.olevba.enable_logging()
         if (log.getEffectiveLevel() == logging.DEBUG):
             log.debug('opening {}'.format(filename))


### PR DESCRIPTION
Hi ! 

Calling vmonkey with the -e argument to evaluate and deobfuscate results as followed 
`vmonkey -e file.virus`
results in 
`NameError: global name 'vm' is not defined`. 

Line 1652 of file `vmonkey.py` is making reference to vm without initializing it. 
This should correct it. 