### PR TITLE
Added support for Write #x call

### DIFF
--- a/vipermonkey/core/strip_lines.py
+++ b/vipermonkey/core/strip_lines.py
@@ -1387,6 +1387,7 @@ def fix_difficult_code(vba_code):
         print vba_code
     vba_code = re.sub(r"[Aa]s\s+#", "as__HASH", vba_code)
     vba_code = re.sub(r"[Pp]ut\s+#", "put__HASH", vba_code)
+    vba_code = re.sub(r"[Ww]rite\s+#", "write__HASH", vba_code)
     vba_code = re.sub(r"[Gg]et\s+#", "get__HASH", vba_code)
     vba_code = re.sub(r"[Cc]lose\s+#", "close__HASH", vba_code)
 
@@ -1686,6 +1687,7 @@ def fix_difficult_code(vba_code):
     # Put the As, Put and Close statements back.
     r = r.replace("as__HASH", "As #")
     r = r.replace("put__HASH", "Put #")
+    r = r.replace("write__HASH", "Write #")
     r = r.replace("get__HASH", "Get #")
     r = r.replace("close__HASH", "Close #")
 


### PR DESCRIPTION
Hey,

I had a bug with a simple VBA macro like this one:
```vba
Sub Auto_Open()
    FileTest = "C:\Users\test\test.txt"
    
    Open FileTest For Output As #1
    Write #1, "Test"
    Close #1
End Sub
```

The actual ViperMonkey commit transformed the source code into this:
```vba
Sub Auto_Open()
    FileTest = "C:\Users\test\test.txt"
    
    Open FileTest For Output As #1
    Write 1, "Test"
    Close #1
End Sub
```

As you can see there is a missing `#` in the `Write` call, to fix this I've added these two lines:
```vba
vba_code = re.sub(r"[Ww]rite\s+#", "write__HASH", vba_code)
r = r.replace("write__HASH", "Write #")
```

I have tested with the code I've put above and it seems to work fine.